### PR TITLE
allow permissioncontroller to find tethering service

### DIFF
--- a/prebuilts/api/30.0/private/permissioncontroller_app.te
+++ b/prebuilts/api/30.0/private/permissioncontroller_app.te
@@ -30,6 +30,7 @@ allow permissioncontroller_app media_session_service:service_manager find;
 allow permissioncontroller_app radio_service:service_manager find;
 allow permissioncontroller_app surfaceflinger_service:service_manager find;
 allow permissioncontroller_app telecom_service:service_manager find;
+allow permissioncontroller_app tethering_service:service_manager find;
 allow permissioncontroller_app trust_service:service_manager find;
 
 # Allow the app to request and collect incident reports.

--- a/private/permissioncontroller_app.te
+++ b/private/permissioncontroller_app.te
@@ -30,6 +30,7 @@ allow permissioncontroller_app media_session_service:service_manager find;
 allow permissioncontroller_app radio_service:service_manager find;
 allow permissioncontroller_app surfaceflinger_service:service_manager find;
 allow permissioncontroller_app telecom_service:service_manager find;
+allow permissioncontroller_app tethering_service:service_manager find;
 allow permissioncontroller_app trust_service:service_manager find;
 
 # Allow the app to request and collect incident reports.


### PR DESCRIPTION
denied  { find } for pid=1921 uid=10168 name=tethering scontext=u:r:permissioncontroller_app:s0:c168,c256,c512,c768 tcontext=u:object_r:tethering_service:s0 tclass=service_manager permissive=0

Signed-off-by: bibarub <bibarub@zohomail.eu>