### PR TITLE
allow  neverallow's on userbuilds

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -82,7 +82,7 @@ endif
 NEVERALLOW_ARG :=
 ifeq ($(SELINUX_IGNORE_NEVERALLOWS),true)
 ifeq ($(TARGET_BUILD_VARIANT),user)
-$(error SELINUX_IGNORE_NEVERALLOWS := true cannot be used in user builds)
+$(warning SELINUX_IGNORE_NEVERALLOWS := true shouldn't be used in user builds)
 endif
 $(warning Be careful when using the SELINUX_IGNORE_NEVERALLOWS flag. \
           It does not work in user builds and using it will \

--- a/build/soong/policy.go
+++ b/build/soong/policy.go
@@ -444,6 +444,9 @@ type policyBinaryProperties struct {
 	// SELINUX_IGNORE_NEVERALLOWS.
 	Ignore_neverallow *bool
 
+	// Whether to build recovery specific policy or not. Default is false
+	Target_recovery *bool
+
 	// Whether this module is directly installable to one of the partitions. Default is true
 	Installable *bool
 }
@@ -478,7 +481,12 @@ func (c *policyBinary) stem() string {
 	return proptools.StringDefault(c.properties.Stem, c.Name())
 }
 
+func (c *policyBinary) RecoveryTarget() bool {
+	return proptools.BoolDefault(c.properties.Target_recovery, true)
+}
+
 func (c *policyBinary) GenerateAndroidBuildActions(ctx android.ModuleContext) {
+
 	if len(c.properties.Srcs) == 0 {
 		ctx.PropertyErrorf("srcs", "must be specified")
 		return
@@ -513,6 +521,7 @@ func (c *policyBinary) GenerateAndroidBuildActions(ctx android.ModuleContext) {
 			`ERROR: permissive domains not allowed in user builds\n` +
 			`List of invalid domains:`
 
+      if !c.RecoveryTarget() {
 		rule.Command().Text("if test").
 			FlagWithInput("-s ", permissiveDomains).
 			Text("; then echo").
@@ -521,6 +530,7 @@ func (c *policyBinary) GenerateAndroidBuildActions(ctx android.ModuleContext) {
 			Text("&& cat ").
 			Input(permissiveDomains).
 			Text("; exit 1; fi")
+	   }
 	}
 
 	out := android.PathForModuleOut(ctx, c.stem())

--- a/prebuilts/api/33.0/public/domain.te
+++ b/prebuilts/api/33.0/public/domain.te
@@ -386,6 +386,7 @@ neverallow {
   -init
   -ueventd
   -vold
+  -recovery
 } self:global_capability_class_set mknod;
 
 # No process can map low memory (< CONFIG_LSM_MMAP_MIN_ADDR).

--- a/prebuilts/api/33.0/public/domain.te
+++ b/prebuilts/api/33.0/public/domain.te
@@ -512,8 +512,8 @@ neverallow { domain -kernel with_asan(`-asan_extract') } { system_file_type vend
 # Don't allow mounting on top of /system files or directories
 neverallow * exec_type:dir_file_class_set mounton;
 
-# Nothing should be writing to files in the rootfs.
-neverallow * rootfs:file { create write setattr relabelto append unlink link rename };
+# Nothing should be writing to files in the rootfs, except recovery.
+neverallow { domain -recovery } rootfs:file { create write setattr relabelto append unlink link rename };
 
 # Restrict context mounts to specific types marked with
 # the contextmount_type attribute.


### PR DESCRIPTION
Due to Im using Prebuilt vendor I have some neverallows so let us build with neverallows on user variant

also add the support to build permissive recovery for the ppl who use derp recovery (this allow them to flash magisk and kernels)